### PR TITLE
feat: add DDE development environment

### DIFF
--- a/.dde/.gitignore
+++ b/.dde/.gitignore
@@ -1,0 +1,4 @@
+data/
+!data/.gitkeep
+snapshots/
+!snapshots/.gitkeep

--- a/.dde/adapters/node-pnpm.sh
+++ b/.dde/adapters/node-pnpm.sh
@@ -7,7 +7,7 @@ detect() {
 configure() {
     export CI=true
     corepack enable
-    corepack prepare pnpm@10.33.0 --activate
+    corepack prepare --activate
     pnpm install --frozen-lockfile --ignore-scripts
     for dir in /home/dde/.cache /app/node_modules; do
         [ -d "$dir" ] && chown -R dde:dde "$dir" 2>/dev/null || true

--- a/.dde/adapters/node-pnpm.sh
+++ b/.dde/adapters/node-pnpm.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+detect() {
+    command -v node >/dev/null 2>&1
+}
+
+configure() {
+    export CI=true
+    corepack enable
+    corepack prepare pnpm@10.33.0 --activate
+    pnpm install --frozen-lockfile --ignore-scripts
+    for dir in /home/dde/.cache /app/node_modules; do
+        [ -d "$dir" ] && chown -R dde:dde "$dir" 2>/dev/null || true
+    done
+}

--- a/.dde/config.yml
+++ b/.dde/config.yml
@@ -1,0 +1,3 @@
+name: parqet.beer
+containers:
+  worker: ~

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+.pnpm-store
 .svelte-kit
 .wrangler
 .dev.vars

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,10 +79,15 @@ dde exec pnpm generate:assets     # OG image / favicons from scripts/generate-as
 pnpm install
 pnpm dev              # Dev server on localhost:5173
 pnpm build            # Build for CF Pages
+pnpm preview          # Wrangler against .svelte-kit/cloudflare — requires `pnpm build` first
 pnpm check            # TypeScript + Svelte check
+pnpm check:watch      # svelte-check in watch mode
 pnpm test             # Vitest
-pnpm lint             # Prettier --check
+pnpm test:watch       # Vitest watch
+pnpm test:e2e         # Playwright
+pnpm lint             # Prettier --check (CI enforced)
 pnpm format           # Prettier
+pnpm generate:assets  # OG image / favicons from scripts/generate-assets.mjs
 ```
 
 ## Gotchas

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,19 +56,33 @@ Cloudflare KV
 
 ## Development
 
+### With DDE (recommended)
+
+```bash
+dde project:up                    # Start container (runs pnpm install via adapter)
+dde exec pnpm dev --host 0.0.0.0 # Dev server (already runs via docker-compose command)
+dde exec pnpm build               # Build for CF Pages
+dde exec pnpm preview             # Wrangler against .svelte-kit/cloudflare — requires build first
+dde exec pnpm check               # TypeScript + Svelte check
+dde exec pnpm check:watch         # svelte-check in watch mode
+dde exec pnpm test                # Vitest
+dde exec pnpm test:watch          # Vitest watch
+dde exec pnpm test:e2e            # Playwright
+dde exec pnpm lint                # Prettier --check (CI enforced)
+dde exec pnpm format              # Prettier
+dde exec pnpm generate:assets     # OG image / favicons from scripts/generate-assets.mjs
+```
+
+### Without DDE
+
 ```bash
 pnpm install
 pnpm dev              # Dev server on localhost:5173
 pnpm build            # Build for CF Pages
-pnpm preview          # Wrangler against .svelte-kit/cloudflare — requires `pnpm build` first
 pnpm check            # TypeScript + Svelte check
-pnpm check:watch      # svelte-check in watch mode
 pnpm test             # Vitest
-pnpm test:watch       # Vitest watch
-pnpm test:e2e         # Playwright
-pnpm lint             # Prettier --check (CI enforced)
+pnpm lint             # Prettier --check
 pnpm format           # Prettier
-pnpm generate:assets  # OG image / favicons from scripts/generate-assets.mjs
 ```
 
 ## Gotchas

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,32 @@ By participating in this project you agree to abide by our
 
 ## Setup
 
+### With DDE (recommended)
+
+You will need:
+
+- **[DDE](https://dde.sh)** — Docker-based development environment
+
+Then:
+
+```bash
+cp .dev.vars.example .dev.vars   # fill in PARQET_CLIENT_ID and SESSION_SECRET
+dde project:up                   # https://parqet-beer.test
+```
+
+Other useful commands:
+
+```bash
+dde exec pnpm check        # TypeScript + svelte-check
+dde exec pnpm test         # Vitest
+dde exec pnpm test:e2e     # Playwright
+dde exec pnpm lint         # Prettier --check (CI enforced)
+dde exec pnpm format       # Prettier write
+dde exec pnpm build        # Build for Cloudflare Pages
+```
+
+### Without DDE
+
 You will need:
 
 - **Node.js** as pinned in [`.nvmrc`](./.nvmrc) (use `nvm use` or an

--- a/README.md
+++ b/README.md
@@ -32,6 +32,27 @@ product.**
 
 ## Setup
 
+### With DDE (recommended)
+
+Prerequisites: [DDE](https://dde.sh).
+
+```bash
+# 1. Clone the repository
+git clone https://github.com/sbaerlocher/parqet.beer.git
+cd parqet.beer
+
+# 2. Copy and fill in environment variables
+cp .dev.vars.example .dev.vars
+# Set PARQET_CLIENT_ID and SESSION_SECRET
+
+# 3. Start the project (installs dependencies automatically)
+dde project:up
+```
+
+Then open `https://parqet-beer.test` in your browser.
+
+### Without DDE
+
 Prerequisites: [Node.js](https://nodejs.org) (see `.nvmrc`), [pnpm](https://pnpm.io).
 
 ```bash
@@ -65,6 +86,18 @@ In production, secrets are set via the Cloudflare dashboard, not through
 `wrangler.jsonc`.
 
 ## Scripts
+
+With DDE, prefix commands with `dde exec`:
+
+```bash
+dde exec pnpm build            # Build for Cloudflare Pages
+dde exec pnpm check            # TypeScript + Svelte check
+dde exec pnpm test             # Vitest (unit tests)
+dde exec pnpm lint             # Prettier check
+dde exec pnpm format           # Prettier write
+```
+
+Without DDE:
 
 ```bash
 pnpm dev              # Vite dev server (localhost:5173)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     working_dir: /app
     volumes:
       - .:/app
-      - /app/node_modules
+      - /app/node_modules # anonymous volumes — run `dde project:down -v` to clear after lockfile changes
       - /app/.svelte-kit
       - /app/.pnpm-store
     command: ['pnpm', 'dev', '--host', '0.0.0.0']

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+---
+services:
+  worker:
+    image: node:24-slim
+    working_dir: /app
+    volumes:
+      - .:/app
+      - /app/node_modules
+      - /app/.svelte-kit
+      - /app/.pnpm-store
+    command: ['pnpm', 'dev', '--host', '0.0.0.0']
+    labels:
+      - 'traefik.enable=true'
+      - 'traefik.http.routers.parqet-beer-worker.rule=Host(`parqet-beer.test`)'
+      - 'traefik.http.routers.parqet-beer-worker.tls=true'
+      - 'traefik.http.services.parqet-beer-worker.loadbalancer.server.port=5173'
+    env_file:
+      - .dev.vars
+
+networks:
+  default:
+    name: dde
+    external: true

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -3,10 +3,12 @@ import * as jose from 'jose';
 import { z } from 'zod';
 import type { Cookies } from '@sveltejs/kit';
 
-/** Resolve the public-facing origin. Behind Traefik (*.test) the internal
- *  connection is plain HTTP, but the client-facing side is always HTTPS. */
-export function resolveOrigin(url: URL): string {
-  return url.hostname.endsWith('.test') ? `https://${url.host}` : url.origin;
+/** Resolve the public-facing origin. Behind a TLS-terminating reverse proxy
+ *  (e.g. Traefik) the internal connection is plain HTTP, but the client-facing
+ *  side is HTTPS — reflected in the X-Forwarded-Proto header. */
+export function resolveOrigin(url: URL, request?: Request): string {
+  const proto = request?.headers.get('x-forwarded-proto') ?? url.protocol.replace(':', '');
+  return `${proto}://${url.host}`;
 }
 
 // `__Host-` prefix enforces Secure, no Domain, Path=/ — blocks sub-domain overwrites.

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -3,6 +3,12 @@ import * as jose from 'jose';
 import { z } from 'zod';
 import type { Cookies } from '@sveltejs/kit';
 
+/** Resolve the public-facing origin. Behind Traefik (*.test) the internal
+ *  connection is plain HTTP, but the client-facing side is always HTTPS. */
+export function resolveOrigin(url: URL): string {
+  return url.hostname.endsWith('.test') ? `https://${url.host}` : url.origin;
+}
+
 // `__Host-` prefix enforces Secure, no Domain, Path=/ — blocks sub-domain overwrites.
 export const SESSION_COOKIE = '__Host-auth_session';
 export const OAUTH_STATE_COOKIE = '__Host-oauth_state';

--- a/src/routes/api/auth/callback/+server.ts
+++ b/src/routes/api/auth/callback/+server.ts
@@ -6,6 +6,7 @@ import {
   setSessionCookie,
   storeTokens,
   resolveSessionSecret,
+  resolveOrigin,
   OAUTH_STATE_COOKIE,
   OAUTH_VERIFIER_COOKIE,
 } from '$lib/server/auth';
@@ -30,7 +31,7 @@ export const GET: RequestHandler = async ({ url, cookies, platform }) => {
     error(400, 'Invalid state parameter');
   }
 
-  const redirectUri = `${url.origin}/api/auth/callback`;
+  const redirectUri = `${resolveOrigin(url)}/api/auth/callback`;
 
   // Exchange code for tokens
   const tokens = await exchangeCodeForTokens(code, redirectUri, env, codeVerifier);

--- a/src/routes/api/auth/callback/+server.ts
+++ b/src/routes/api/auth/callback/+server.ts
@@ -11,7 +11,7 @@ import {
   OAUTH_VERIFIER_COOKIE,
 } from '$lib/server/auth';
 
-export const GET: RequestHandler = async ({ url, cookies, platform }) => {
+export const GET: RequestHandler = async ({ url, cookies, platform, request }) => {
   const env = platform!.env;
 
   const code = url.searchParams.get('code');
@@ -31,7 +31,7 @@ export const GET: RequestHandler = async ({ url, cookies, platform }) => {
     error(400, 'Invalid state parameter');
   }
 
-  const redirectUri = `${resolveOrigin(url)}/api/auth/callback`;
+  const redirectUri = `${resolveOrigin(url, request)}/api/auth/callback`;
 
   // Exchange code for tokens
   const tokens = await exchangeCodeForTokens(code, redirectUri, env, codeVerifier);

--- a/src/routes/api/auth/login/+server.ts
+++ b/src/routes/api/auth/login/+server.ts
@@ -2,7 +2,7 @@
 import { redirect } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { generateCodeVerifier, generateCodeChallenge, generateState } from '$lib/server/pkce';
-import { OAUTH_STATE_COOKIE, OAUTH_VERIFIER_COOKIE } from '$lib/server/auth';
+import { OAUTH_STATE_COOKIE, OAUTH_VERIFIER_COOKIE, resolveOrigin } from '$lib/server/auth';
 
 export const GET: RequestHandler = async ({ platform, cookies, url }) => {
   const env = platform!.env;
@@ -28,7 +28,7 @@ export const GET: RequestHandler = async ({ platform, cookies, url }) => {
     path: '/',
   });
 
-  const redirectUri = `${url.origin}/api/auth/callback`;
+  const redirectUri = `${resolveOrigin(url)}/api/auth/callback`;
 
   const params = new URLSearchParams({
     response_type: 'code',

--- a/src/routes/api/auth/login/+server.ts
+++ b/src/routes/api/auth/login/+server.ts
@@ -4,7 +4,7 @@ import type { RequestHandler } from './$types';
 import { generateCodeVerifier, generateCodeChallenge, generateState } from '$lib/server/pkce';
 import { OAUTH_STATE_COOKIE, OAUTH_VERIFIER_COOKIE, resolveOrigin } from '$lib/server/auth';
 
-export const GET: RequestHandler = async ({ platform, cookies, url }) => {
+export const GET: RequestHandler = async ({ platform, cookies, url, request }) => {
   const env = platform!.env;
 
   const codeVerifier = generateCodeVerifier();
@@ -28,7 +28,7 @@ export const GET: RequestHandler = async ({ platform, cookies, url }) => {
     path: '/',
   });
 
-  const redirectUri = `${resolveOrigin(url)}/api/auth/callback`;
+  const redirectUri = `${resolveOrigin(url, request)}/api/auth/callback`;
 
   const params = new URLSearchParams({
     response_type: 'code',

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -3,6 +3,7 @@ import {
   createSessionCookie,
   getUserIdFromCookie,
   resolveSessionSecret,
+  resolveOrigin,
   clearUserKv,
   storeTokens,
   getTokens,
@@ -83,6 +84,32 @@ describe('resolveSessionSecret', () => {
       SESSION_SECRET_DEV: '',
     } as unknown as App.Platform['env'];
     await expect(resolveSessionSecret(env)).rejects.toThrow('no secret');
+  });
+});
+
+describe('resolveOrigin', () => {
+  it('returns plain HTTP origin for localhost', () => {
+    const url = new URL('http://localhost:5173/api/auth/login');
+    expect(resolveOrigin(url)).toBe('http://localhost:5173');
+  });
+
+  it('returns HTTPS when X-Forwarded-Proto is https', () => {
+    const url = new URL('http://parqet-beer.test:5173/api/auth/login');
+    const request = new Request(url, {
+      headers: { 'x-forwarded-proto': 'https' },
+    });
+    expect(resolveOrigin(url, request)).toBe('https://parqet-beer.test:5173');
+  });
+
+  it('falls back to url.protocol when no request is provided', () => {
+    const url = new URL('https://parqet.beer/api/auth/login');
+    expect(resolveOrigin(url)).toBe('https://parqet.beer');
+  });
+
+  it('falls back to url.protocol when header is missing', () => {
+    const url = new URL('http://localhost:5173/api/auth/login');
+    const request = new Request(url);
+    expect(resolveOrigin(url, request)).toBe('http://localhost:5173');
   });
 });
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,4 +4,7 @@ import { defineConfig } from 'vite';
 
 export default defineConfig({
   plugins: [tailwindcss(), sveltekit()],
+  server: {
+    allowedHosts: ['parqet-beer.test'],
+  },
 });


### PR DESCRIPTION
## Summary

- Add DDE configuration (`.dde/`, `docker-compose.yml`) with node-pnpm adapter for containerized local development via Traefik (`parqet-beer.test`)
- Add `resolveOrigin()` helper for OAuth redirects behind Traefik HTTPS termination
- Remove unnecessary DDE plugins in favor of `dde exec`
- Update AGENTS.md, README.md, and CONTRIBUTING.md with DDE setup instructions

## Test plan

- [ ] `dde project:up` starts the container and installs dependencies
- [ ] `https://parqet-beer.test` serves the app
- [ ] OAuth login/callback works through Traefik
- [ ] `dde exec pnpm check` and `dde exec pnpm test` pass
- [ ] Setup without DDE (`pnpm install && pnpm dev`) still works