### PR TITLE
feat: v0.3.0 new beers, changelog, version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes documented here. Format: [Keep a Changelog](https://keepacha
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-04-22
+
+### Added
+
+- DDE development environment with Docker, Traefik (`parqet-beer.test`),
+  and node-pnpm adapter for containerised local development.
+- `resolveOrigin()` helper using `X-Forwarded-Proto` for OAuth redirects
+  behind TLS-terminating reverse proxies.
+- DDE setup instructions in README, CONTRIBUTING, and AGENTS docs.
+- Gampert Bräu Förster Pils (500ml, DE) and Kulmbacher Edelherb (500ml, DE)
+  to beer data.
+
+### Changed
+
+- pnpm version in DDE adapter reads from `package.json` via
+  `corepack prepare --activate` (single source of truth).
+
+### Removed
+
+- Redundant DDE plugins (`build`, `check`, `lint`, `lint-fix`, `test`,
+  `shell`) replaced by `dde exec pnpm <command>`.
+
 ## [0.2.0] - 2026-04-20
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parqet-beer",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/src/lib/data/beer.json
+++ b/src/lib/data/beer.json
@@ -119,6 +119,20 @@
     "country": "DE"
   },
   {
+    "name": "Gampert Bräu Förster Pils",
+    "size": "500ml",
+    "price": 1.5,
+    "currency": "EUR",
+    "country": "DE"
+  },
+  {
+    "name": "Kulmbacher Edelherb",
+    "size": "500ml",
+    "price": 1.09,
+    "currency": "EUR",
+    "country": "DE"
+  },
+  {
     "name": "Appenzeller Quöllfrisch",
     "size": "330ml",
     "price": 1.2,
@@ -208,19 +222,5 @@
     "price": 3.0,
     "currency": "CHF",
     "country": "CH"
-  },
-  {
-    "name": "Gampert Bräu Förster Pils",
-    "size": "500ml",
-    "price": 1.5,
-    "currency": "EUR",
-    "country": "DE"
-  },
-  {
-    "name": "Kulmbacher Edelherb",
-    "size": "500ml",
-    "price": 0.55,
-    "currency": "EUR",
-    "country": "DE"
   }
 ]

--- a/src/lib/data/beer.json
+++ b/src/lib/data/beer.json
@@ -208,5 +208,19 @@
     "price": 3.0,
     "currency": "CHF",
     "country": "CH"
+  },
+  {
+    "name": "Gampert Bräu Förster Pils",
+    "size": "500ml",
+    "price": 1.5,
+    "currency": "EUR",
+    "country": "DE"
+  },
+  {
+    "name": "Kulmbacher Edelherb",
+    "size": "500ml",
+    "price": 0.55,
+    "currency": "EUR",
+    "country": "DE"
   }
 ]


### PR DESCRIPTION
## Summary

Release cut for v0.3.0. The changelog consolidates work from multiple PRs:
- PR #1: DDE development environment (already merged to main)
- This PR: new beer data + version bump

Changes in this PR:
- Add Gampert Bräu Förster Pils (500ml, 1.50 EUR, DE) and Kulmbacher Edelherb (500ml, 1.09 EUR, DE) to beer data
- Update CHANGELOG.md with v0.3.0 entries
- Bump version to 0.3.0

## Test plan

- [ ] `pnpm check` passes
- [ ] `pnpm test` passes
- [ ] Beer entries render correctly on dashboard