### PR TITLE
fix: auth flow UX + logout 403 behind TLS proxy

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -9,6 +9,11 @@ declare global {
       locale: 'de' | 'en';
     }
 
+    interface PageData {
+      locale?: 'de' | 'en';
+      authenticated?: boolean;
+    }
+
     interface Platform {
       env: {
         PARQET_KV: KVNamespace;

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -6,6 +6,7 @@ export const translations = {
     // Landing
     tagline: 'Dein Portfolio in Bier umgerechnet.',
     connectButton: 'Mit Parqet verbinden',
+    openDashboardButton: 'Dashboard öffnen',
     readOnly: 'Read-only Zugriff. Wir können nichts an deinem Portfolio ändern.',
 
     // Dashboard
@@ -124,6 +125,7 @@ export const translations = {
     // Landing
     tagline: 'Your portfolio converted into beer.',
     connectButton: 'Connect with Parqet',
+    openDashboardButton: 'Open dashboard',
     readOnly: "Read-only access. We can't change anything in your portfolio.",
 
     // Dashboard

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -9,5 +9,6 @@ import type { LayoutServerLoad } from './$types';
 export const load: LayoutServerLoad = ({ locals }) => {
   return {
     locale: locals.locale ?? 'de',
+    authenticated: locals.session !== null,
   };
 };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,7 +7,7 @@
   import ThemeToggle from '$lib/components/ThemeToggle.svelte';
   import RotatingTagline from '$lib/components/RotatingTagline.svelte';
 
-  const authenticated = $derived(page.data['authenticated'] === true);
+  const authenticated = $derived(page.data.authenticated === true);
 
   // Live ticker state for R3 flash effect
   const tickerBase = [
@@ -104,6 +104,7 @@
         <div class="mt-8 flex gap-3 items-center flex-wrap">
           <a
             href={authenticated ? '/dashboard' : '/api/auth/login'}
+            data-testid="hero-cta"
             class="btn btn-primary"
             style="padding: 14px 22px; font-size: 15px; border-radius: 10px"
           >

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,10 +1,13 @@
 <!-- SPDX-License-Identifier: MIT -->
 <script lang="ts">
+  import { page } from '$app/state';
   import { t } from '$lib/stores/locale';
   import { locale } from '$lib/stores/locale';
   import LocaleToggle from '$lib/components/LocaleToggle.svelte';
   import ThemeToggle from '$lib/components/ThemeToggle.svelte';
   import RotatingTagline from '$lib/components/RotatingTagline.svelte';
+
+  const authenticated = $derived(page.data['authenticated'] === true);
 
   // Live ticker state for R3 flash effect
   const tickerBase = [
@@ -100,7 +103,7 @@
 
         <div class="mt-8 flex gap-3 items-center flex-wrap">
           <a
-            href="/api/auth/login"
+            href={authenticated ? '/dashboard' : '/api/auth/login'}
             class="btn btn-primary"
             style="padding: 14px 22px; font-size: 15px; border-radius: 10px"
           >
@@ -110,7 +113,7 @@
               aria-hidden="true"
               style="width: 20px; height: 20px"
             />
-            {$t.connectButton} →
+            {authenticated ? $t.openDashboardButton : $t.connectButton} →
           </a>
           <span class="font-mono text-xs text-amber-700">
             🔒 {$t.readOnly}

--- a/src/routes/api/auth/login/+server.ts
+++ b/src/routes/api/auth/login/+server.ts
@@ -4,7 +4,14 @@ import type { RequestHandler } from './$types';
 import { generateCodeVerifier, generateCodeChallenge, generateState } from '$lib/server/pkce';
 import { OAUTH_STATE_COOKIE, OAUTH_VERIFIER_COOKIE, resolveOrigin } from '$lib/server/auth';
 
-export const GET: RequestHandler = async ({ platform, cookies, url, request }) => {
+export const GET: RequestHandler = async ({ platform, cookies, url, request, locals }) => {
+  // Already authenticated — skip the Parqet round-trip. Avoids burning a PKCE
+  // verifier, a rate-limit slot, and an authorize request just to land back
+  // where the user clicked from.
+  if (locals.session) {
+    redirect(302, '/dashboard');
+  }
+
   const env = platform!.env;
 
   const codeVerifier = generateCodeVerifier();

--- a/src/routes/api/auth/logout/+server.ts
+++ b/src/routes/api/auth/logout/+server.ts
@@ -1,16 +1,18 @@
 // SPDX-License-Identifier: MIT
 import { redirect, error } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { clearSessionCookie, clearUserKv } from '$lib/server/auth';
+import { clearSessionCookie, clearUserKv, resolveOrigin } from '$lib/server/auth';
 
 export const POST: RequestHandler = async ({ cookies, platform, locals, request, url }) => {
   // Defence in depth on top of SvelteKit's built-in form-POST CSRF check.
   // Browsers send `Origin` on cross-origin POSTs, so mismatches are a clear
   // signal to block. If the header is absent we fall through — modern
   // browsers send it reliably for POST and SvelteKit's Content-Type guard
-  // still applies.
+  // still applies. Compare against `resolveOrigin` (not `url.origin`) so the
+  // check survives a TLS-terminating reverse proxy, where `url.protocol` is
+  // `http:` while the browser sent the request as `https:`.
   const origin = request.headers.get('origin');
-  if (origin && origin !== url.origin) {
+  if (origin && origin !== resolveOrigin(url, request)) {
     error(403, 'Forbidden');
   }
 

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -4,11 +4,10 @@ test.describe('parqet.beer smoke', () => {
   test('landing page renders with connect button', async ({ page }) => {
     await page.goto('/');
     await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
-    // Target the CTA by its href, not its text — the footer also contains a
-    // "Parqet" link, and the CTA's label changes with locale ("Mit Parqet
-    // verbinden" / "Connect with Parqet"). The `/api/auth/login` href is the
-    // stable contract for this element.
-    await expect(page.locator('a[href="/api/auth/login"]')).toBeVisible();
+    // Target the CTA by `data-testid` — the href is dynamic (flips between
+    // `/api/auth/login` and `/dashboard` depending on session state) and the
+    // label varies by locale.
+    await expect(page.getByTestId('hero-cta')).toBeVisible();
   });
 
   test('landing page exposes OG meta tags', async ({ page }) => {


### PR DESCRIPTION
## Summary

- **feat**: `/api/auth/login` short-circuits to `/dashboard` when `locals.session` is set, and the landing-page CTA flips to "Open dashboard". Previously clicking "Connect" while already authenticated burned a full Parqet authorize round-trip (PKCE cookies, rate-limit slot) just to land back on the dashboard.
- **fix**: logout's defence-in-depth origin check now routes through `resolveOrigin` (same helper login/callback use) so it honors `x-forwarded-proto`. Behind a TLS-terminating reverse proxy (Traefik in the DDE dev setup), SvelteKit's `url.protocol` is `http:` while browsers send `Origin: https://…` — the direct string compare was 403'ing every legitimate logout. Cross-origin spoofing stays blocked.

## Test plan

- [x] `pnpm check` — 0 errors, 0 warnings
- [x] `pnpm test` — 163/163 pass
- [x] `pnpm lint` — clean
- [x] curl `POST /api/auth/logout` with `Origin: https://parqet-beer.test` → `303 → /` (was 403)
- [x] curl `POST /api/auth/logout` with `Origin: https://evil.example` → `403` (CSRF guard intact)
- [ ] Manual: verify landing CTA text switches based on session cookie
- [ ] Manual: verify logged-in `/api/auth/login` goes straight to `/dashboard`