### PR TITLE
feat: add Schoenramer Hell to beer list

### DIFF
--- a/src/lib/data/beer.json
+++ b/src/lib/data/beer.json
@@ -133,6 +133,13 @@
     "country": "DE"
   },
   {
+    "name": "Schönramer Hell",
+    "size": "500ml",
+    "price": 1.5,
+    "currency": "EUR",
+    "country": "DE"
+  },
+  {
     "name": "Appenzeller Quöllfrisch",
     "size": "330ml",
     "price": 1.2,


### PR DESCRIPTION
One of the best beers was missing -- Schoenramer Hell (0.5l, 1.50 EUR) is finally on the list.