### PR TITLE
fix(auth): clear phantom session cookie when server can't resolve it

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -5,6 +5,8 @@ import {
   getTokens,
   storeTokens,
   resolveSessionSecret,
+  clearSessionCookie,
+  SESSION_COOKIE,
   type FullSession,
 } from '$lib/server/auth';
 import { refreshAccessToken } from '$lib/server/parqet-client';
@@ -134,6 +136,14 @@ export const handle: Handle = async ({ event, resolve }) => {
     // is an async binding in production and a plain string in local dev.
     const sessionSecret = await resolveSessionSecret(env);
 
+    // A session cookie that can't be resolved into a live session is "phantom"
+    // state — the browser keeps presenting it, but every server check returns
+    // null. Actively clear it so the client stops carrying dead authentication
+    // state and the UI shows the correct logged-out affordances immediately.
+    // Three cases end up here: undecryptable cookie (e.g. SESSION_SECRET was
+    // rotated), decrypted userId but no KV token (30d TTL expired or cache
+    // wiped), and malformed KV payload (Zod reject inside `getTokens`).
+    const hasSessionCookie = event.cookies.get(SESSION_COOKIE) !== undefined;
     const userId = await getUserId(event.cookies, sessionSecret);
     if (userId) {
       const tokenData = await getTokens(env.PARQET_KV, userId);
@@ -147,11 +157,12 @@ export const handle: Handle = async ({ event, resolve }) => {
         const session = await maybeRefreshSession(full, env);
         event.locals.session = { userId: session.userId, accessToken: session.accessToken };
       } else {
-        // Cookie exists but tokens are gone from KV (expired after 30d).
         event.locals.session = null;
+        clearSessionCookie(event.cookies);
       }
     } else {
       event.locals.session = null;
+      if (hasSessionCookie) clearSessionCookie(event.cookies);
     }
 
     // adapter-cloudflare resolves this from cf-connecting-ip, so no manual

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -183,7 +183,7 @@ describe('hooks.server handle()', () => {
   });
 
   describe('cookie exists but tokens missing from KV', () => {
-    it('sets locals.session to null', async () => {
+    it('sets locals.session to null and clears the phantom cookie', async () => {
       const cookies = createFakeCookies();
       const kv = createFakeKv();
       // Set cookie but do NOT seed KV tokens
@@ -194,6 +194,39 @@ describe('hooks.server handle()', () => {
       await runHandle(ctx.event);
 
       expect(ctx.event.locals.session).toBeNull();
+      // Cookie is stripped from the response so the browser stops presenting it.
+      expect(cookies.store.has(SESSION_COOKIE)).toBe(false);
+    });
+  });
+
+  describe('cookie is undecryptable (e.g. SESSION_SECRET rotated)', () => {
+    it('sets locals.session to null and clears the dead cookie', async () => {
+      const cookies = createFakeCookies();
+      const kv = createFakeKv();
+      // Cookie encrypted with a different secret — current secret can't decrypt.
+      const foreignCookie = await createSessionCookie(
+        'user-foreign',
+        'a-different-secret-long-enough-to-pass!'
+      );
+      cookies.store.set(SESSION_COOKIE, foreignCookie);
+
+      const ctx = buildEvent({ pathname: '/', cookies, kv });
+      await runHandle(ctx.event);
+
+      expect(ctx.event.locals.session).toBeNull();
+      expect(cookies.store.has(SESSION_COOKIE)).toBe(false);
+    });
+
+    it('does not emit Set-Cookie when there was no session cookie to begin with', async () => {
+      const cookies = createFakeCookies();
+      const deleteSpy = vi.spyOn(cookies.cookies, 'delete');
+
+      const ctx = buildEvent({ pathname: '/', cookies });
+      await runHandle(ctx.event);
+
+      expect(ctx.event.locals.session).toBeNull();
+      expect(deleteSpy).not.toHaveBeenCalledWith(SESSION_COOKIE, expect.anything());
+      deleteSpy.mockRestore();
     });
   });
 


### PR DESCRIPTION
## Summary

- Observed today: client browser appeared "logged in" (cookie present in DevTools) while the server-side session was actually null. The cookie kept getting re-sent on every request because nothing told the browser to drop it.
- Fix: `hooks.server.ts` now calls `clearSessionCookie()` whenever a session cookie is present but can't be resolved into a live session — undecryptable (e.g. `SESSION_SECRET` rotated), decrypted but no matching KV token entry (30d TTL elapsed, cache wiped), or KV payload fails Zod validation.
- Impact: the next request after any of these states arrives cookie-clean. The landing page, direct `/dashboard` hits, and any client-side auth assumptions all line up without waiting for an OAuth callback to overwrite the dead cookie.

Not touched: KV TTL auto-expiry (already handled), reactive 401 cleanup in `/api/portfolios` and `/api/performance` (already clears cookie + KV), explicit logout (already clears both). Those all continue to work; the fix only closes the gap where the server quietly knows a session is dead but doesn't tell the browser.

## Test plan

- [ ] `pnpm check` — 0 errors, 0 warnings
- [ ] `pnpm test` — all pass (3 new hook-level cases)
- [ ] `pnpm lint`
- [ ] `pnpm build`
- [ ] Manual: rotate `SESSION_SECRET` locally → reload page → observe `__Host-auth_session` disappears from DevTools after the first response
- [ ] Manual: delete `token:{userId}` from KV while logged in → reload → cookie gone, landing shows "Connect with Parqet"