### PR TITLE
fix(components): use crypto.randomUUID for glass uid

### DIFF
--- a/src/lib/components/glass-motion.svelte.ts
+++ b/src/lib/components/glass-motion.svelte.ts
@@ -7,7 +7,9 @@ import { cubicOut } from 'svelte/easing';
 // projects it into its own SVG coordinates (usually `topY + (1 - fill) * range`).
 // `uid` is per-instance for SVG id suffixes (gradients, clipPaths).
 export function useGlassFill(getFill: () => number, initialFill = 0.68) {
-  const uid = Math.random().toString(36).slice(2, 8);
+  const uid = Array.from(crypto.getRandomValues(new Uint8Array(4)), (b) =>
+    b.toString(16).padStart(2, '0')
+  ).join('');
   const animated = new Tween(initialFill, { duration: 800, easing: cubicOut });
   const clamp = (n: number) => Math.max(0.05, Math.min(0.95, n));
 


### PR DESCRIPTION
## Summary

- Replaces `Math.random()` with `crypto.getRandomValues()` (4 bytes → 8 hex chars) in `useGlassFill` for the per-instance SVG id suffix.
- Resolves CodeQL alert [#1](https://github.com/sbaerlocher/parqet.beer/security/code-scanning/1) (`js/insecure-randomness`, CWE-338).
- The `uid` is only used to scope `<linearGradient>` / `<clipPath>` ids per glass component instance — not security-sensitive in practice — but switching to a CSPRNG silences the rule cleanly.
- Matches the existing convention in [src/lib/server/pkce.ts](src/lib/server/pkce.ts). `crypto.randomUUID()` would also work but requires a secure context in Chrome/Safari, which would break LAN-IP dev testing (`http://192.168.x.x:5173`) on mobile — `getRandomValues` has no such restriction.

## Test plan

- [x] `pnpm check` (TypeScript + Svelte) — 0 errors / 0 warnings
- [x] `pnpm test` (Vitest) — 173/173 passing
- [x] pre-commit hooks (prettier, eslint) green
- [x] pre-push hooks (test, typecheck) green
- [ ] CodeQL re-scan closes alert #1 after merge