### PR TITLE
fix(build): approve lefthook build script for pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,8 +58,9 @@
   "pnpm": {
     "onlyBuiltDependencies": [
       "esbuild",
-      "workerd",
-      "sharp"
+      "lefthook",
+      "sharp",
+      "workerd"
     ]
   }
 }


### PR DESCRIPTION
## Summary

- Cloudflare Pages aborts the install with `ERR_PNPM_IGNORED_BUILDS` because pnpm runs in strict-dep-builds mode and `lefthook@2.1.6` was not on the allow-list.
- Add `lefthook` to `pnpm.onlyBuiltDependencies` alongside `esbuild`, `sharp`, `workerd`. Its `lefthook install` postinstall is idempotent with the existing `prepare` hook (`scripts/install-hooks.mjs`).

## Test plan

- [ ] CI green
- [ ] Cloudflare Pages preview deploy succeeds (no `ERR_PNPM_IGNORED_BUILDS`)