### PR TITLE
chore(build): migrate pnpm config to pnpm-workspace.yaml for v11

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "license": "MIT",
   "type": "module",
-  "packageManager": "pnpm@10.33.2",
+  "packageManager": "pnpm@11.0.9",
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",
@@ -54,13 +54,5 @@
     "vite": "8.0.9",
     "vitest": "4.1.5",
     "wrangler": "4.87.0"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild",
-      "lefthook",
-      "sharp",
-      "workerd"
-    ]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+allowBuilds:
+  esbuild: true
+  lefthook: true
+  sharp: true
+  workerd: true


### PR DESCRIPTION
## Summary

- pnpm 11 stopped reading the `pnpm` field in `package.json` and replaced `onlyBuiltDependencies` with a new `allowBuilds` map that must live in `pnpm-workspace.yaml` — without this migration, the approval list silently disappears on v11 and `pnpm install` aborts with `ERR_PNPM_IGNORED_BUILDS`. This is what blocks the Renovate bump in #39.
- Applied via the official `pnpx codemod run pnpm-v10-to-v11`: moves the build-script allow list into `pnpm-workspace.yaml`, bumps `packageManager` to `pnpm@11.0.9`, and drops the now-defunct `pnpm` block from `package.json`.

## Test plan

- [ ] CI green on pnpm 11
- [ ] `pnpm install --frozen-lockfile` succeeds with `strict-dep-builds` (verified locally on 11.0.9)
- [ ] Cloudflare Workers Build succeeds
- [ ] After merge: Renovate PR #39 rebases onto main and turns green